### PR TITLE
[review] KR-149 support for Selenium IDE exported test suites for the JavaScript formatter

### DIFF
--- a/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
+++ b/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
@@ -288,7 +288,7 @@ function formatSuite(testSuite, filename) {
   for (var i = 0; i < testSuite.tests.length; ++i) {
     // have saved or loaded a suite
     if (typeof testSuite.tests[i].filename !== 'undefined') {
-      formattedSuite += "require(__dirname + '/' + '" + filename + '/' + testSuite.tests[i].filename.replace(/\.\w+$/, '') + "');\n";
+      formattedSuite += "require(__dirname + '/' + '" + filename + '/' + testSuite.tests[i].filename.replace(/\.\w+$/, '').replace(/\.js$/, '') + "');\n";
     } else {
       // didn't load / save as a suite
       var testFile = testSuite.tests[i].getTitle();

--- a/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
+++ b/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
@@ -288,7 +288,7 @@ function formatSuite(testSuite, filename) {
   for (var i = 0; i < testSuite.tests.length; ++i) {
     // have saved or loaded a suite
     if (typeof testSuite.tests[i].filename !== 'undefined') {
-      formattedSuite += "require(__dirname + '/' + '" + filename.replace(/\.js$/, '') + '/' + testSuite.tests[i].filename.replace(/\.\w+$/, '') + "');\n";
+      formattedSuite += "require(__dirname + '/' + '" + filename.replace(/\.js$/, '') + '/' + testSuite.tests[i].filename.replace(/\.\w+$/, '') + ".js');\n";
     } else {
       // didn't load / save as a suite
       var testFile = testSuite.tests[i].getTitle();

--- a/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
+++ b/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
@@ -288,7 +288,7 @@ function formatSuite(testSuite, filename) {
   for (var i = 0; i < testSuite.tests.length; ++i) {
     // have saved or loaded a suite
     if (typeof testSuite.tests[i].filename !== 'undefined') {
-      formattedSuite += "require(__dirname + '/' + '" + filename + '/' + testSuite.tests[i].filename.replace(/\.\w+$/, '').replace(/\.js$/, '') + "');\n";
+      formattedSuite += "require(__dirname + '/' + '" + filename.replace(/\.js$/, '') + '/' + testSuite.tests[i].filename.replace(/\.\w+$/, '') + "');\n";
     } else {
       // didn't load / save as a suite
       var testFile = testSuite.tests[i].getTitle();

--- a/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
+++ b/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
@@ -318,7 +318,7 @@ this.options = {
           '    beforeEach(function (done) {\n' +
           "        driver = require('./client.js').driver.build();\n" +
           '        driver.manage().timeouts().implicitlyWait(30000);\n' +
-          "        baseUrl = '${baseURL}';\n" +
+          "        baseUrl = process.env.BASE_URL || '${baseURL}';\n" +
           '        verificationErrors = [];\n' +
           '        done();\n' +
           '    });\n' +

--- a/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
+++ b/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
@@ -319,7 +319,7 @@ this.options = {
           '    var verificationErrors;\n' +
           '\n' +
           '    beforeEach(function (done) {\n' +
-          "        driver = require('./client.js').driver;\n" +
+          "        driver = require('./client.js').driver.build();\n" +
           '        driver.manage().timeouts().implicitlyWait(30000);\n' +
           "        baseUrl = '${baseURL}';\n" +
           '        verificationErrors = [];\n' +

--- a/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
+++ b/ide/plugins/javascript-format/src/content/formats/javascript-wd-mocha.js
@@ -283,19 +283,16 @@ this.sendKeysMaping = {
  * @param filename   the file the formatted suite will be saved as
  */
 function formatSuite(testSuite, filename) {
-  formattedSuite = "var webdriver = require('selenium-webdriver');\n" +
-      "var driver = require('./client.js').driver;\n" +
-      '\n' +
-      '\n';
+  formattedSuite = '';
 
   for (var i = 0; i < testSuite.tests.length; ++i) {
     // have saved or loaded a suite
-    if (typeof testSuite.tests[i].filename != 'undefined') {
-      formattedSuite += 'require File.join(File.dirname(__FILE__),  "' + testSuite.tests[i].filename.replace(/\.\w+$/, '') + '")\n';
+    if (typeof testSuite.tests[i].filename !== 'undefined') {
+      formattedSuite += "require(__dirname + '/' + '" + filename + '/' + testSuite.tests[i].filename.replace(/\.\w+$/, '') + "');\n";
     } else {
       // didn't load / save as a suite
       var testFile = testSuite.tests[i].getTitle();
-      formattedSuite += 'require "' + testFile + '"\n';
+      formattedSuite += "require('" + testFile + "')\n";
     }
   }
   return formattedSuite;

--- a/ide/plugins/javascript-format/src/install.rdf
+++ b/ide/plugins/javascript-format/src/install.rdf
@@ -4,7 +4,7 @@
     <Description about="urn:mozilla:install-manifest">
         <em:id>javascriptformatters@compstak.com</em:id>
         <em:name>Selenium IDE: JavaScript Formatters</em:name>
-        <em:version>1.1.0</em:version>
+        <em:version>1.1.1</em:version>
         <em:creator>Adam Goucher</em:creator>
         <em:developer>Nuno Pinge</em:developer>
         <em:description>JavaScript code formatters for Selenium IDE</em:description>


### PR DESCRIPTION
this pull request adds support for test suites using mocha.
here's how the test suite and the test cases folder structure should look like

``` bash
.                    <dir>
..                   <dir>
test_suite           <dir>
test_suite.js
```

the test cases should go in the `test_suite` folder and to execute the test_suite you just need to run mocha with the `test_suite.js` file:

``` bash
mocha -t 30000 test/test_suite.js
```

you can also specify a base URL by using an environment variable:

``` bash
BASE_URL=http://another.com mocha -t 30000 test/test_suite.js
```
